### PR TITLE
Use Integer instead of Fixnum to avoid warning on ruby 2.4+

### DIFF
--- a/lib/spider/spider_instance.rb
+++ b/lib/spider/spider_instance.rb
@@ -123,7 +123,7 @@ class SpiderInstance
   def on(code, p = nil, &block)
     f = p ? p : block
     case code
-    when Fixnum
+    when Integer
       @callbacks[code] = f
     else
       @callbacks[code.to_sym] = f


### PR DESCRIPTION
ruby 2.4 combined Fixnum and Bignum into Integer, and Fixnum and
Bignum should not be referenced anymore.  This should be backwards
compatible with older versions of ruby.