### PR TITLE
Add Redis as cache wrapper to track cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ scraping, collecting, and looping so that you can just handle the data._
  end
 ```
 
+### Use Redis to track cycles
+
+```ruby
+ require 'spider'
+ require 'spider/included_in_redis'
+ Spider.start_at('http://cashcats.biz/') do |s|
+   s.check_already_seen_with IncludedInRedis.new(host: '127.0.0.1', port: 6379)
+ end
+```
+
 ### Track cycles with a custom object
 
 ```ruby

--- a/lib/spider/included_in_redis.rb
+++ b/lib/spider/included_in_redis.rb
@@ -1,0 +1,31 @@
+# Use Redis to track cycles.
+
+require 'redis'
+require 'json'
+
+# A specialized class using Redis to track items stored. It supports
+# three operations: new, <<, and include? . Together these can be used to
+# add items to Redis, then determine whether the item has been added.
+#
+# To use it with Spider use the check_already_seen_with method:
+#
+#  Spider.start_at('http://example.com/') do |s|
+#    s.check_already_seen_with IncludedInRedis.new(host: '127.0.0.1', port: 6379)
+#  end
+class IncludedInRedis
+  # Construct a new IncludedInRedis instance. All arguments here are
+  # passed to Redis (part of the redis gem).
+  def initialize(*a)
+    @c = Redis.new(*a)
+  end
+
+  # Add an item to Redis
+  def <<(v)
+    @c.set(v.to_s, v.to_json)
+  end
+
+  # True if the item is in Redis
+  def include?(v)
+    @c.get(v.to_s) == v.to_json
+  end
+end

--- a/spec/spider/included_in_redis_spec.rb
+++ b/spec/spider/included_in_redis_spec.rb
@@ -1,0 +1,43 @@
+require File.dirname(__FILE__)+'/../spec_helper'
+
+def before_specing_redis
+  local_require 'spider/included_in_redis'
+  system('redis-server 127.0.0.1:6379')
+end
+
+def after_specing_redis
+  system('kill -KILL `pidof redis-server`')
+end
+
+Spec::Runner.configure { |c| c.mock_with :mocha }
+
+describe 'Object to halt cycles' do
+  before do
+    before_specing_redis
+  end
+
+  it 'should understand <<' do
+    c = IncludedInRedis.new(host: 'localhost', port: 6379)
+    c.should respond_to(:<<)
+  end
+
+  it 'should understand included?' do
+    c = IncludedInRedis.new(host: 'localhost', port: 6379)
+    c.should respond_to(:include?)
+  end
+
+  it 'should produce false if the object is not included' do
+    c = IncludedInRedis.new(host: 'localhost', port: 6379)
+    c.include?('a').should be_false
+  end
+
+  it 'should produce true if the object is included' do
+    c = IncludedInRedis.new(host: 'localhost', port: 6379)
+    c << 'a'
+    c.include?('a').should be_true
+  end
+  
+  after do
+    after_specing_redis
+  end
+end


### PR DESCRIPTION
As I required persistent storage to track already seen URLs from spider and because memcached does not persist its data I quickly added a new class `IncludedInRedis` to be able to use Redis instead. That class is based on your `IncludedInMemcached` class and works smoothly. The only difference is that in Redis I have to serialize the value using `to_json` and as such it requires the `json` gem along with the `redis` gem.