### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/spider.gemspec
+++ b/spider.gemspec
@@ -9,7 +9,6 @@ spec = Gem::Specification.new do |s|
   s.has_rdoc = true
   s.homepage = 'https://github.com/johnnagro/spider'
   s.name = 'spider'
-  s.rubyforge_project = 'spider'
   s.summary = 'A Web spidering library'
   s.files = Dir['**/*'].delete_if { |f| f =~ /(cvs|gem|svn)$/i }
   s.require_path = 'lib'


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436